### PR TITLE
Fix moon phase translations in Dutch language file

### DIFF
--- a/src/languages/nl.json
+++ b/src/languages/nl.json
@@ -7,10 +7,10 @@
             "fullMoon": "Volle maan",
             "thirdQuarterMoon": "Laatste kwartier",
             "newMoon": "Nieuwe maan",
-            "waxingCrescentMoon": "Afnemende halve maan",
-            "waxingGibbousMoon": "Afnemende maan",
-            "waningCrescentMoon": "Wassende halve maan",
-            "waningGibbousMoon": "Wassende maan"
+            "waxingCrescentMoon": "Wassende halve maan",
+            "waxingGibbousMoon": "Wassende maan",
+            "waningCrescentMoon": "Afnemende halve maan",
+            "waningGibbousMoon": "Afnemende maan"
         },
         "illumination": "Verlichting ",
         "illuminated": " Verlicht ",


### PR DESCRIPTION
This pull request fixes the incorrect translations for moon phases in the Dutch language file. The translations for "waxingCrescentMoon" and "waxingGibbousMoon" were swapped, as well as the translations for "waningCrescentMoon" and "waningGibbousMoon". This PR corrects the translations to ensure accurate representation of the moon phases in the Dutch language.