### PR TITLE
Update de.json to fix the moon phase labels

### DIFF
--- a/src/languages/de.json
+++ b/src/languages/de.json
@@ -3,14 +3,14 @@
     "nativeName": "Deutsch",
     "card": {
         "phase": {
-            "firstQuarterMoon": "Erstes Viertel",
+            "firstQuarterMoon": "Zunehmender Halbmond",
             "fullMoon": "Vollmond",
-            "thirdQuarterMoon": "Letztes Viertel",
+            "thirdQuarterMoon": "Abnehmender Halbmond",
             "newMoon": "Neumond",
-            "waxingCrescentMoon": "Zunehmende Sichel",
-            "waxingGibbousMoon": "Zunehmender Halbmond",
-            "waningCrescentMoon": "Abnehmender Halbmond",
-            "waningGibbousMoon": "Abnehmende Sichel"
+            "waxingCrescentMoon": "Zunehmender Sichelmond",
+            "waxingGibbousMoon": "Zunehm. Dreiviertelmond",
+            "waningCrescentMoon": "Abnehmender Sichelmond",
+            "waningGibbousMoon": "Abnehm. Dreiviertelmond"
         },
         "illumination": "Beleuchtung",
         "illuminated": "beleuchtet",
@@ -20,9 +20,9 @@
         "moonAge": "Alter",
         "distance": "Entfernung",
         "azimuth": "Azimut",
-        "altitude": "Höhe",
-        "fullMoon": "Nächster Vollmond",
-        "newMoon": "Nächster Neumond",
+        "altitude": "Elevation",
+        "fullMoon": "Vollmond",
+        "newMoon": "Neumond",
         "relativeTime": {
             "days": "Tage",
             "justNow": "jetzt",


### PR DESCRIPTION
This fixes [[Bug] Wrong German translations of the moon phases](https://github.com/ngocjohn/lunar-phase-card/issues/42#top) 

- Replaces the wrong German translation of several moon phases
- Removes the extra "Nächster" part (not present in English) from the upcoming full moon and new moon events as these labels are too long for smaller screens.
- Changes "Höhe" to "Elevation" to clearly differentiate this vertical angle from the distance to the moon.

The labels for the two "Dreiviertelmond" phases are abbreviated to better fit the limited space on smaller screens.