### PR TITLE
Replace deprecated ha-button small size value

### DIFF
--- a/src/lunar-phase-card/editor/shared/nav-bar.ts
+++ b/src/lunar-phase-card/editor/shared/nav-bar.ts
@@ -26,10 +26,10 @@ export const createSecondaryCodeLabel = (yamlMode: boolean, button: boolean = fa
   const icon = yamlMode ? 'mdi:table-edit' : 'mdi:code-json';
   const buttonLabel = yamlMode ? 'Close Editor' : 'Edit YAML';
   if (!button) {
-    return html` <ha-button size="small" variant=${variant} appearance="filled"> ${buttonLabel} </ha-button> `;
+    return html` <ha-button size="s" variant=${variant} appearance="filled"> ${buttonLabel} </ha-button> `;
   }
   return html`
-    <ha-button size="small" variant=${variant} appearance="filled"><ha-icon .icon=${icon}></ha-icon></ha-button>
+    <ha-button size="s" variant=${variant} appearance="filled"><ha-icon .icon=${icon}></ha-icon></ha-button>
   `;
 };
 
@@ -84,7 +84,7 @@ export class NavBar extends LitElement {
                     ${this.secondaryAction
                       ? this.secondaryAction
                       : html`
-                          <ha-button size="small" variant="neutral" appearance="filled">
+                          <ha-button size="s" variant="neutral" appearance="filled">
                             ${this.secondaryLabel}
                           </ha-button>
                         `}


### PR DESCRIPTION
## Summary
- replace deprecated ha-button size="small" values with size="s" in the editor nav bar
- keep the existing variants, appearances, labels, and icons unchanged

## Verification
- confirmed src/lunar-phase-card/editor/shared/nav-bar.ts has 0 remaining size="small" matches
- confirmed the three affected ha-button elements now use size="s"
- confirmed the change is exactly the small -> s replacement requested by issue #96

Fixes #96