### PR TITLE
fix: handling of location latitude and longitude from entity

### DIFF
--- a/src/lunar-phase-card/lunar-phase-card.ts
+++ b/src/lunar-phase-card/lunar-phase-card.ts
@@ -327,7 +327,10 @@ export class LunarPhaseCard extends LunarBaseCard {
   private createMoon() {
     const initData = {
       date: this._date,
-      config: this.config,
+      config: {
+        ...this.config,
+        ...this._configLatLong,
+      },
       locale: this._configLocale,
     };
     this.moon = new Moon(initData);


### PR DESCRIPTION
Update the configuration to include latitude and longitude when creating the moon instance.

Fixes: #95